### PR TITLE
Additionally write error and audit logs to syslog

### DIFF
--- a/discovery/ds.php
+++ b/discovery/ds.php
@@ -21,6 +21,8 @@ require_once('languages.php');
 // Set P3P headers just in case they were not set in Apache already
 header('P3P: CP="NOI CUR DEVa OUR IND COM NAV PRE"');
 
+openlog('discoveryservice', LOG_PID | LOG_PERROR, LOG_ERR);
+
 // Set default config options
 initConfigOptions();
 

--- a/discovery/functions.php
+++ b/discovery/functions.php
@@ -705,6 +705,8 @@ function logError($message){
                 return;
         }
 
+	syslog(LOG_ERR, $message);
+
 	if (is_writable($WAYFLogFile.'.error')) {
 
 	    $entry = date('Y-m-d H:i:s').' '.$message."\n";
@@ -736,7 +738,18 @@ function logAccessEntry($protocol, $type, $sp, $idp){
 	if (!$useLogging){
 		return;
 	}
-	
+
+	$json = json_encode(Array(
+		'date' => date('Y-m-d H:i:s'),
+		'ip' => $_SERVER['REMOTE_ADDR'],
+		'protocol' => $protocol,
+		'type' => $type,
+		'idp' => $idp,
+		'sp' => $_GET['entityID'],
+		'return_url' => $sp
+	));
+	syslog(LOG_NOTICE, $json);
+
 	// Let's make sure the file exists and is writable first.
 	if (is_writable($WAYFLogFile)) {
 			


### PR DESCRIPTION
DS logs will be sent via syslog to fluentd, so we need syslog as an additional logging target.